### PR TITLE
use round instead of intval to convert amount to kobo

### DIFF
--- a/modules/gateways/paystack.php
+++ b/modules/gateways/paystack.php
@@ -111,7 +111,7 @@ function paystack_link($params)
     
     // Invoice
     $invoiceId = $params['invoiceid'];
-    $amountinkobo = intval(floatval($params['amount'])*100);
+    $amountinkobo = round(floatval($params['amount'])*100);
     $currency = $params['currency'];
     ///Transaction_reference
     $txnref         = $invoiceId . '_' .time();


### PR DESCRIPTION
Why was this change made?

A bug was reported where the Paystack checkout was loading a different amount than what was set in WHMCS, we traced this to an error in the line

$amountinkobo = intval(floatval($params['amount']) * 100); //where $params['amount'] is 19.74, the checkout loaded 19.73 instead.

It's unclear why this is happening, but using round() in place of intval() appears to resolve the issue.



Ref #? (Enter an issue this references.)
https://paystack.zendesk.com/agent/tickets/944623
----- READ, then delete below this line -----

IMPORTANT!

Please be sure to send a coherent commit history - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting. Here's an article we'd like you to read > http://chris.beams.io/posts/git-commit/

