### PR TITLE
fees-fix

### DIFF
--- a/modules/gateways/callback/paystack.php
+++ b/modules/gateways/callback/paystack.php
@@ -300,7 +300,10 @@ if ($success) {
 
     $amount = floatval($txStatus->amount)/100;
     $requested_amount = floatval($txStatus->requested_amount)/100;
-    if (isset($requested_amount) && $requested_amount > 0) $amount = $requested_amount
+    if (isset($requested_amount) && $requested_amount > 0) 
+    {
+        $amount = $requested_amount;
+    }
     $fees = floatval($txStatus->fees)/100;
     if ($gatewayParams['convertto']) {
         $result = select_query("tblclients", "tblinvoices.invoicenum,tblclients.currency,tblcurrencies.code", array("tblinvoices.id" => $invoiceId), "", "", "", "tblinvoices ON tblinvoices.userid=tblclients.id INNER JOIN tblcurrencies ON tblcurrencies.id=tblclients.currency");


### PR DESCRIPTION
Why was this change made? It seems that missing open and close curly braces on line 303 of the callback/paystack.php file could potentially be the reason why the invoice is not being marked as paid and the fees are not being added.

Fixes #? (20)

Ref #? (20)


